### PR TITLE
Django services: Add CORS headers (allow all)

### DIFF
--- a/config/settings_basic.py
+++ b/config/settings_basic.py
@@ -33,6 +33,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = (
     'apps.common',
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -49,6 +50,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -92,6 +94,8 @@ REST_FRAMEWORK = {
     ),
     'ORDERING_PARAM': 'sort'
 }
+
+CORS_ORIGIN_ALLOW_ALL = True
 
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ djangorestframework==2.4.1
 django-rest-swagger==0.1.14
 django-filter==0.7
 django-apptemplates==0.0.1
+django-cors-headers==0.13
 psycopg2==2.5.4
 requests==2.4.0
 pandas==0.14.1


### PR DESCRIPTION
CORS headers are required, if a client from a different domain wants to
access JSON data through XHR (AJAX).

This is required if we want to deploy the policycompass backend and frontend on different domains, which is a necessity if ports cannot be used (e.g. due to restrictive firewalls), and useful anyways.
