### PR TITLE
added time_resolution for events

### DIFF
--- a/apps/eventsmanager/plugin.py
+++ b/apps/eventsmanager/plugin.py
@@ -1,0 +1,19 @@
+import imp
+import os
+
+PluginFolder = os.path.join(os.path.dirname(__file__), 'plugins')
+MainModule = "__init__"
+
+def getPlugins():
+    plugins = []
+    possibleplugins = os.listdir(PluginFolder)
+    for i in possibleplugins:
+        location = os.path.join(PluginFolder, i)
+        if not os.path.isdir(location) or not MainModule + ".py" in os.listdir(location):
+            continue
+        info = imp.find_module(MainModule, [location])
+        plugins.append({"name": i, "info": info})
+    return plugins
+
+def loadPlugin(plugin):
+    return imp.load_module(MainModule, *plugin["info"])

--- a/apps/eventsmanager/plugins/hello/__init__.py
+++ b/apps/eventsmanager/plugins/hello/__init__.py
@@ -1,0 +1,2 @@
+def run():
+    print("Hello from a plugin!")

--- a/apps/eventsmanager/views.py
+++ b/apps/eventsmanager/views.py
@@ -8,7 +8,7 @@ from rest_framework.reverse import reverse
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from SPARQLWrapper import SPARQLWrapper, JSON
-#from .plugin import getPlugins, loadPlugin
+from .plugin import getPlugins, loadPlugin
 
 import json
 
@@ -79,10 +79,10 @@ class EventInstanceView(generics.RetrieveUpdateDestroyAPIView):
 
 @api_view(['GET'])
 def harvest_events(request):
-    # for i in getPlugins():
-    #     print("Loading plugin " + i["name"])
-    #     plugin = loadPlugin(i)
-    #     plugin.run()
+    for i in getPlugins():
+        print("Loading plugin " + i["name"])
+        plugin = loadPlugin(i)
+        plugin.run()
     start = request.QUERY_PARAMS.get('start', None)
     if start is None:
         start = "0001-01-01"

--- a/apps/eventsmanager/views.py
+++ b/apps/eventsmanager/views.py
@@ -8,6 +8,8 @@ from rest_framework.reverse import reverse
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from SPARQLWrapper import SPARQLWrapper, JSON
+#from .plugin import getPlugins, loadPlugin
+
 import json
 
 class Base(APIView):
@@ -36,7 +38,32 @@ class EventView(generics.ListCreateAPIView):
         title = self.request.QUERY_PARAMS.get('title', None)
         start = self.request.QUERY_PARAMS.get('start', None)
         end = self.request.QUERY_PARAMS.get('end', None)
+        time_resolution = self.request.QUERY_PARAMS.get('time_resolution', None)
         if start and end is not None:
+            if time_resolution is not None:
+                if time_resolution == 'year':
+                    start = start + '-01-01'
+                    end = end + '-12-31'
+                elif time_resolution == 'month':
+                    start = start + '-01'
+                    end = end + '-31'
+                elif time_resolution == 'quarter':
+                    if start[-2:].lower() == 'q1':
+                        start = start[:4] + '-01-01'
+                    elif start[-2:].lower() == 'q2':
+                        start = start[:4] + '-04-01'
+                    elif start[-2:].lower() == 'q3':
+                        start = start[:4] + '-07-01'
+                    elif start[-2:].lower() == 'q4':
+                        start = start[:4] + '-10-01'
+                    if end[-2:].lower() == 'q1':
+                        end = end[:4] + '-03-31'
+                    elif end[-2:].lower() == 'q2':
+                        end = end[:4] + '-06-30'
+                    elif end[-2:].lower() == 'q3':
+                        end = end[:4] + '-09-30'
+                    elif end[-2:].lower() == 'q4':
+                        end = end[:4] + '-12-31'
             if validate_date(start) and validate_date(end) is not None:
                 queryset2 = queryset
                 queryset = queryset.filter(Q(startEventDate__range=[start, end]) | Q(endEventDate__range=[start, end]))
@@ -52,6 +79,10 @@ class EventInstanceView(generics.RetrieveUpdateDestroyAPIView):
 
 @api_view(['GET'])
 def harvest_events(request):
+    # for i in getPlugins():
+    #     print("Loading plugin " + i["name"])
+    #     plugin = loadPlugin(i)
+    #     plugin.run()
     start = request.QUERY_PARAMS.get('start', None)
     if start is None:
         start = "0001-01-01"
@@ -82,6 +113,6 @@ def harvest_events(request):
     results = sparql.query().convert()
     output = []
     for key in results["results"]["bindings"]:
-        output.append({"title": key["label"]["value"], "description": key["comment"]["value"], "date": key["date"]["value"], "url": key["event"]["value"]})
+        output.append({"title": key["label"]["value"], "description": key["comment"]["value"], "date": key["date"]["value"]+"T00:00:00Z", "url": key["event"]["value"]})
     #Example Request: http://localhost:8000/api/v1/eventsmanager/harvestevents?start=1968-10-30&end=1980-12-31&keyword=war
     return Response(output)


### PR DESCRIPTION
This adds the ability to change the granularity by year, quarter, month or day when searching for an event through the API
Example: GET /api/v1/eventsmanager/events?title=Test&start=2014&end=2014&time_resolution=year
For Further explenation see the API documentation of the Events Manager