### PR TITLE
Authenticate against adhocracy

### DIFF
--- a/config/settings_basic.py
+++ b/config/settings_basic.py
@@ -160,3 +160,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Path to adhocracy settings
+ADHOCRACY_BASE_URL = 'http://localhost:6541'

--- a/policycompass_services/api.py
+++ b/policycompass_services/api.py
@@ -4,7 +4,8 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.permissions import IsAuthenticated
+from policycompass_services.permissions import IsAdhocracyGod
 from policycompass_services.auth import AdhocracyAuthentication
 
 class Base(APIView):
@@ -33,7 +34,7 @@ class ExampleAuthenticated(APIView):
 class ExampleAdmin(APIView):
 
      authentication_classes = (AdhocracyAuthentication,)
-     permission_classes = (IsAdminUser,)
+     permission_classes = (IsAdhocracyGod,)
 
      def get(self, request, format=None):
           return Response("Success")

--- a/policycompass_services/api.py
+++ b/policycompass_services/api.py
@@ -4,6 +4,8 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from policycompass_services.auth import AdhocracyAuthentication
 
 class Base(APIView):
 
@@ -19,3 +21,19 @@ class Base(APIView):
         }
 
         return Response(result)
+
+class ExampleAuthenticated(APIView):
+
+     authentication_classes = (AdhocracyAuthentication,)
+     permission_classes = (IsAuthenticated,)
+
+     def get(self, request, format=None):
+          return Response("Success")
+
+class ExampleAdmin(APIView):
+
+     authentication_classes = (AdhocracyAuthentication,)
+     permission_classes = (IsAdminUser,)
+
+     def get(self, request, format=None):
+          return Response("Success")

--- a/policycompass_services/auth.py
+++ b/policycompass_services/auth.py
@@ -53,6 +53,7 @@ class AdhocracyUser:
 
     def __init__(self, user_ressource_path, is_god = False):
         self.resource_path = user_ressource_path
+        self.is_god = True
         self.is_staff = False
         self.is_superuser = is_god
         self.user_permissions = []
@@ -80,7 +81,7 @@ class AdhocracyUser:
         raise NotImplementedError
 
     def __repr__(self):
-        return "AdhocracyUser('%s', is_admin=%r)" % (self.resource_path, self.is_superuser)
+        return "AdhocracyUser('%s', is_god=%r)" % (self.resource_path, self.is_god)
 
 class AdhocracyAuthentication(authentication.BaseAuthentication):
 

--- a/policycompass_services/auth.py
+++ b/policycompass_services/auth.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 from cgi import parse_header
 import json
 
+from django.conf import settings
 from rest_framework import authentication
 from rest_framework import exceptions, HTTP_HEADER_ENCODING
 from rest_framework.authentication import get_authorization_header
@@ -84,7 +85,7 @@ class AdhocracyUser:
 class AdhocracyAuthentication(authentication.BaseAuthentication):
 
     def authenticate(self, request):
-        adhocracy_base_url = 'http://localhost:6541'
+        adhocracy_base_url = settings.ADHOCRACY_BASE_URL
         user_path = request.META.get('HTTP_X_USER_PATH')
         user_token = request.META.get('HTTP_X_USER_TOKEN')
         user_url = urljoin(adhocracy_base_url, user_path)

--- a/policycompass_services/permissions.py
+++ b/policycompass_services/permissions.py
@@ -1,0 +1,9 @@
+from rest_framework.permissions import BasePermission
+from .auth import AdhocracyUser
+
+class IsAdhocracyGod(BasePermission):
+    """
+    Allow only adhocracy users of group god to access
+    """
+    def has_permission(self, request, view):
+        return request.user and type(request.user) is AdhocracyUser and request.user.is_god

--- a/policycompass_services/urls.py
+++ b/policycompass_services/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from django.http import HttpResponseRedirect
-from .api import Base
+from .api import Base, ExampleAuthenticated, ExampleAdmin
 #from config import settings
 from django.conf import settings
 
@@ -20,6 +20,8 @@ urlpatterns = patterns('',
     url(r'^admin/', include(admin.site.urls)),
     url(r'^docs/', include('rest_framework_swagger.urls'), name='swagger'),
     url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.PC_SERVICES['references']['MEDIA_URL'],}),
+    url(r'^example/auth/anyuser$', ExampleAuthenticated.as_view()),
+    url(r'^example/auth/adminuser$', ExampleAdmin.as_view()),
     # For the time being redirect to swagger
     url(r'^$', lambda x: HttpResponseRedirect('/api/v1'))
 


### PR DESCRIPTION
Contains a an Django Rest Framework authentication provider, which can be used to authenticate against an Adhocracy instance.

Currently it is not the default auth provider maybe it should it.