### PR TITLE
Allow cache-control header through CORS

### DIFF
--- a/config/settings_basic.py
+++ b/config/settings_basic.py
@@ -109,6 +109,7 @@ CORS_ALLOW_HEADERS = (
     'x-csrftoken',
     'x-user-path',
     'x-user-token',
+    'cache-control'
 )
 
 TEMPLATE_LOADERS = (


### PR DESCRIPTION
- allow header since it is needed by dropzone