### PR TITLE
Moved back to debug true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ apps/searchmanager/elasticsearch
 apps/visualizationsmanager/phantomCapture/node_modules
 
 pip-selfcheck.json
+
+#Static Directory
+static/

--- a/config/settings_basic.py
+++ b/config/settings_basic.py
@@ -20,14 +20,11 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 SECRET_KEY = '6v!+maxc&d^ofd_0teo2-0264vd&0)5qplr+y3&vfc0^l#z6jp'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
-#DEBUG = False
+DEBUG = True
 
 TEMPLATE_DEBUG = True
 
-ALLOWED_HOSTS = ['localhost', '.policycompass.eu']
-#ALLOWED_HOSTS = ['localhost']
-
+ALLOWED_HOSTS = ['localhost']
 
 # Application definition
 


### PR DESCRIPTION
This PR sets the service by default back to debug=true. This setting will be handled by the base repo in production. 