### PR TITLE
Remove Creator Path Validator for Indicator and Dataset

### DIFF
--- a/apps/datasetmanager/models.py
+++ b/apps/datasetmanager/models.py
@@ -42,7 +42,7 @@ class Dataset(models.Model):
     time_end = models.CharField(max_length=20)
 
     language_id = models.IntegerField()  # RP languages
-    creator_path = models.CharField(max_length=1024, validators=[RegexValidator("^(/[^/]*)+/?$")])
+    creator_path = models.CharField(max_length=1024)
     unit_id = models.IntegerField()  # RP unit
     indicator_id = models.IntegerField()  # IS indicator
     class_id = models.IntegerField()  # RP class

--- a/apps/indicatorservice/models.py
+++ b/apps/indicatorservice/models.py
@@ -19,7 +19,7 @@ class Indicator(models.Model):
     issued = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 
-    creator_path = models.CharField(max_length=1024, validators=[RegexValidator("^(/[^/]*)+/?$")])
+    creator_path = models.CharField(max_length=1024)
 
     # Private property to handle the policy domains
     _policy_domains = None


### PR DESCRIPTION
This PR removes the validator for creator path for Indicator and Dataset. The validation was not valid for our case and caused problems in the django admin backend