### PR TITLE
Install flake8 locally

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ xmltodict==0.9.2
 voluptuous==0.8.7
 grako==3.6.3
 drf-compound-fields==0.2.2
+flake8==2.5.0


### PR DESCRIPTION
First step for a post-commit hook (policycompass/policycompass#380).

This means that flake8 will also be installed in production setups, but I wouldn't care, we don't differentiate production and devolpment anyway.