### PR TITLE
Check coding style with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: python
+python:
+  - "3.4"
+install:
+  - pyvenv .
+  - bin/pip install flake8
+script:
+  - bin/flake8 apps policycompass_services --ignore E501,F403 --exclude migrations


### PR DESCRIPTION
In order to verify that this actually works, I've created a subbranch [test-broken-coding-style](https://github.com/policycompass/policycompass-services/tree/test-broken-coding-style) with the bad commit 58bf12bc9ce1a6b3b9f384b19c900d0a16f11b10.

Travis indeed reports brokenness:

    https://travis-ci.org/policycompass/policycompass-services/builds/95635642

This fixes policycompass/policycompass#389.