### PR TITLE
description field mandatory in model

### DIFF
--- a/apps/visualizationsmanager/migrations/0012_auto_20160726_1208.py
+++ b/apps/visualizationsmanager/migrations/0012_auto_20160726_1208.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('visualizationsmanager', '0011_visualization_derived_from_id'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='visualization',
+            name='description',
+            field=models.TextField(),
+        ),
+    ]

--- a/apps/visualizationsmanager/models.py
+++ b/apps/visualizationsmanager/models.py
@@ -12,7 +12,7 @@ class VisualizationType(models.Model):
 class Visualization(models.Model):
     # Meta Data by User Input
     title = models.CharField(max_length=100)
-    description = models.TextField(blank=True)
+    description = models.TextField()
     keywords = models.CharField(max_length=200, blank=True)
     # issued = models.DateTimeField()
     # publisher = models.CharField(max_length=200, blank=True)


### PR DESCRIPTION
PR related with issue 604 policycompass/policycompass/issues/604

To be able to control all the mandatory fields by the Messages in Pop Up, the description must be mandatory in the visualisation model.


