### PR TITLE
added license_id to dataset model

### DIFF
--- a/apps/datasetmanager/migrations/0008_dataset_license_id.py
+++ b/apps/datasetmanager/migrations/0008_dataset_license_id.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('datasetmanager', '0007_auto_20160413_1512'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dataset',
+            name='license_id',
+            field=models.IntegerField(blank=True, null=True),
+            preserve_default=False,
+        ),
+    ]

--- a/apps/datasetmanager/migrations/0009_auto_20160808_1549.py
+++ b/apps/datasetmanager/migrations/0009_auto_20160808_1549.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.apps import apps as django_apps
+
+def assign_license(apps, schema_editor):
+    Dataset = apps.get_model("datasetmanager", "Dataset")
+    License = django_apps.get_model("referencepool", "License")
+    licenses_list = License.objects.all()
+    for dataset in Dataset.objects.all():
+        if len(dataset.license) > 0:
+            for license in licenses_list:
+                if dataset.license == license.title or dataset.license == license.identifier or dataset.license == license.url:
+                    dataset.license_id = license.id
+                    dataset.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('datasetmanager', '0008_dataset_license_id'),
+    ]
+
+    operations = [
+        migrations.RunPython(assign_license),
+    ]

--- a/apps/datasetmanager/models.py
+++ b/apps/datasetmanager/models.py
@@ -34,6 +34,8 @@ class Dataset(models.Model):
 
     license = models.CharField(max_length=100, blank=True)
 
+    license_id = models.IntegerField(blank=True, null=True)
+
     version = models.IntegerField(editable=False)
 
     time_resolution = models.CharField(max_length=10, choices=RESOLUTIONS)


### PR DESCRIPTION
Requires: https://github.com/policycompass/policycompass-services/pull/140

The ID of the license from the referencepool will be saved in "license_id" field. 

The "assign_license" function in the "apps/datasetmanager/migrations/0009_auto_20160808_1549.py" file, will transform existing licenses to the new license_id field.