### PR TITLE
Rename date fields in visualisation model

### DIFF
--- a/apps/visualizationsmanager/api.py
+++ b/apps/visualizationsmanager/api.py
@@ -205,7 +205,7 @@ class VisualizationList(APIView):
     # Sets the fields, which can be searched
     search_fields = ('title', 'keywords')
     # Sets the fields, which are available for sorting
-    #ordering_fields = ('created_at', 'updated_at', 'title')
+    # ordering_fields = ('created_at', 'updated_at', 'title')
     ordering_fields = ('date_created', 'date_modified', 'title')
 
     def get(self, request):

--- a/apps/visualizationsmanager/api.py
+++ b/apps/visualizationsmanager/api.py
@@ -205,7 +205,8 @@ class VisualizationList(APIView):
     # Sets the fields, which can be searched
     search_fields = ('title', 'keywords')
     # Sets the fields, which are available for sorting
-    ordering_fields = ('created_at', 'updated_at', 'title')
+    #ordering_fields = ('created_at', 'updated_at', 'title')
+    ordering_fields = ('date_created', 'date_modified', 'title')
 
     def get(self, request):
         """

--- a/apps/visualizationsmanager/migrations/0013_auto_20160916_0657.py
+++ b/apps/visualizationsmanager/migrations/0013_auto_20160916_0657.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('visualizationsmanager', '0012_auto_20160726_1208'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='visualization',
+            old_name='created_at',
+            new_name='date_created',
+        ),
+        migrations.RenameField(
+            model_name='visualization',
+            old_name='updated_at',
+            new_name='date_modified',
+        ),
+        migrations.RemoveField(
+            model_name='visualization',
+            name='views_count',
+        ),
+    ]

--- a/apps/visualizationsmanager/models.py
+++ b/apps/visualizationsmanager/models.py
@@ -21,12 +21,14 @@ class Visualization(models.Model):
     location = models.IntegerField(blank=True, null=True)
 
     # Auto-Generated Meta Data
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    #created_at = models.DateTimeField(auto_now_add=True)
+    date_created = models.DateTimeField(auto_now_add=True)
+    #updated_at = models.DateTimeField(auto_now=True)
+    date_modified = models.DateTimeField(auto_now=True)
     creator_path = models.CharField(max_length=1024, validators=[
         RegexValidator("^(/[^/]*)+/?$")])
 
-    views_count = models.IntegerField()
+    #views_count = models.IntegerField()
     visualization_type_id = models.IntegerField()
     status_flag_id = models.IntegerField()
     filter_configuration = models.CharField(max_length=800)

--- a/apps/visualizationsmanager/models.py
+++ b/apps/visualizationsmanager/models.py
@@ -21,14 +21,14 @@ class Visualization(models.Model):
     location = models.IntegerField(blank=True, null=True)
 
     # Auto-Generated Meta Data
-    #created_at = models.DateTimeField(auto_now_add=True)
+    # created_at = models.DateTimeField(auto_now_add=True)
     date_created = models.DateTimeField(auto_now_add=True)
-    #updated_at = models.DateTimeField(auto_now=True)
+    # updated_at = models.DateTimeField(auto_now=True)
     date_modified = models.DateTimeField(auto_now=True)
     creator_path = models.CharField(max_length=1024, validators=[
         RegexValidator("^(/[^/]*)+/?$")])
 
-    #views_count = models.IntegerField()
+    # views_count = models.IntegerField()
     visualization_type_id = models.IntegerField()
     status_flag_id = models.IntegerField()
     filter_configuration = models.CharField(max_length=800)

--- a/apps/visualizationsmanager/serializers.py
+++ b/apps/visualizationsmanager/serializers.py
@@ -69,9 +69,11 @@ class PaginatedListVisualizationLinkedByEventSerializer(pagination.PaginationSer
 
 class BaseVisualizationSerializer(ModelSerializer):
     creator_path = serializers.Field(source='creator_path')
-    created_at = serializers.DateField(source='created_at', read_only=True)
-    updated_at = serializers.DateField(source='updated_at', read_only=True)
-    views_count = serializers.IntegerField(source='views_count')
+    #created_at = serializers.DateField(source='created_at', read_only=True)
+    date_created = serializers.DateField(source='date_created', read_only=True)
+    #updated_at = serializers.DateField(source='updated_at', read_only=True)
+    date_modified = serializers.DateField(source='date_modified', read_only=True)
+    #views_count = serializers.IntegerField(source='views_count')
     visualization_type_id = serializers.IntegerField(
         source='visualization_type_id')
     status_flag_id = serializers.IntegerField(source='status_flag_id')

--- a/apps/visualizationsmanager/serializers.py
+++ b/apps/visualizationsmanager/serializers.py
@@ -69,11 +69,11 @@ class PaginatedListVisualizationLinkedByEventSerializer(pagination.PaginationSer
 
 class BaseVisualizationSerializer(ModelSerializer):
     creator_path = serializers.Field(source='creator_path')
-    #created_at = serializers.DateField(source='created_at', read_only=True)
+    # created_at = serializers.DateField(source='created_at', read_only=True)
     date_created = serializers.DateField(source='date_created', read_only=True)
-    #updated_at = serializers.DateField(source='updated_at', read_only=True)
+    # updated_at = serializers.DateField(source='updated_at', read_only=True)
     date_modified = serializers.DateField(source='date_modified', read_only=True)
-    #views_count = serializers.IntegerField(source='views_count')
+    # views_count = serializers.IntegerField(source='views_count')
     visualization_type_id = serializers.IntegerField(
         source='visualization_type_id')
     status_flag_id = serializers.IntegerField(source='status_flag_id')


### PR DESCRIPTION
PR to rename date fields in the visualisation model

created_at -> date_created
updated_at -> date_modified
views_count -> delete it, we don't use it